### PR TITLE
Validate returns all errors

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,5 @@
 {
   "typescript.tsdk": "./node_modules/typescript/lib",
-
   // Files to exclude from the sidebar
   "files.exclude": {
     "lib/": true,

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -2,7 +2,10 @@
   "compilerOptions": {
     "module": "commonjs",
     "target": "es5",
-    "lib": ["es2015", "dom"],
+    "lib": [
+      "es2015",
+      "dom"
+    ],
     "strict": true,
     "declaration": true,
     "sourceMap": false,

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -80,9 +80,10 @@ export function checked(...runtypes: Runtype[]) {
         const parameterIndex = validParameterIndices[typeIndex];
         const validated = type.validate(args[parameterIndex]);
         if (!validated.success) {
+          // TODO: TBD exception format
           throw new ValidationError(
-            `${methodId}, argument #${parameterIndex}: ${validated.message}`,
-            validated.key,
+            `${methodId}, argument #${parameterIndex}: ${validated.errors[0].message}`,
+            validated.errors[0].key,
           );
         }
       });

--- a/src/result.ts
+++ b/src/result.ts
@@ -22,15 +22,17 @@ export type Failure = {
    */
   success: false;
 
-  /**
-   * A message indicating the reason validation failed.
-   */
-  message: string;
+  errors: Array<{
+    /**
+     * A message indicating the reason validation failed.
+     */
+    message: string;
 
-  /**
-   * A key indicating the location at which validation failed.
-   */
-  key?: string;
+    /**
+     * A key indicating the location at which validation failed.
+     */
+    key?: string;
+  }>;
 };
 
 /**

--- a/src/types/never.ts
+++ b/src/types/never.ts
@@ -10,7 +10,11 @@ export interface Never extends Runtype<never> {
 export const Never = create<Never>(
   value => ({
     success: false,
-    message: `Expected nothing, but was ${value === null ? value : typeof value}`,
+    errors: [
+      {
+        message: `Expected nothing, but was ${value === null ? value : typeof value}`,
+      },
+    ],
   }),
   { tag: 'never' },
 );


### PR DESCRIPTION
TODO:

1. discuss breaking changes to `Failure`
1. since there will be breaking changes, can we also make `check` and `validate` async? I want to be able to use `withConstraint` with network call and thus promises.
1. finish the validator changes

Currently
1. typecheck failing with 33 errors
1. tests failing with 429 units